### PR TITLE
fix(deps): upgrade Django to 2.0.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
   "flask==0.12",
   "requests==2.19.1",
   "PyYAML==5.3.1",
-  "django==2.0.0",
+  "django==2.0.10",
   "jinja2<3.1.0",
   "werkzeug<1.0.0",
   "itsdangerous<1.0.0"


### PR DESCRIPTION
This pull request upgrades Django to version 2.0.10 to address a high severity vulnerability.

Advisory URL: https://github.com/kcyap/python-vuln-demo/security/dependabot/24

Generated via MCP demo.