### PR TITLE
fix(deps): upgrade requests to 2.32.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
   "flask==0.12",
-  "requests==2.19.1",
+  "requests==2.32.4",
   "PyYAML==5.3.1",
   "django==2.0.0",
   "jinja2<3.1.0",


### PR DESCRIPTION
This pull request upgrades requests to version 2.32.4 to address a medium severity vulnerability.

Advisory URL: https://github.com/kcyap/python-vuln-demo/security/dependabot/31

Generated via MCP demo.