### PR TITLE
fix(deps): upgrade Jinja2 to 3.1.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
   "requests==2.19.1",
   "PyYAML==5.3.1",
   "django==2.0.0",
-  "jinja2<3.1.0",
+  "jinja2==3.1.6",
   "werkzeug<1.0.0",
   "itsdangerous<1.0.0"
 ]


### PR DESCRIPTION
This pull request upgrades Jinja2 to version 3.1.6 to address a medium severity vulnerability.

Advisory URL: https://github.com/kcyap/python-vuln-demo/security/dependabot/29

Generated via MCP demo.