### PR TITLE
fix(deps): upgrade werkzeug to 3.0.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,6 @@ dependencies = [
   "PyYAML==5.3.1",
   "django==2.0.0",
   "jinja2<3.1.0",
-  "werkzeug<1.0.0",
+  "werkzeug==3.0.6",
   "itsdangerous<1.0.0"
 ]


### PR DESCRIPTION
This pull request upgrades werkzeug to version 3.0.6 to address a medium severity vulnerability.

Advisory URL: https://github.com/kcyap/python-vuln-demo/security/dependabot/27

Generated via MCP demo.